### PR TITLE
fix: ensure operator can delete Jobs

### DIFF
--- a/charts/kwasm-operator/templates/role.yaml
+++ b/charts/kwasm-operator/templates/role.yaml
@@ -13,3 +13,4 @@ rules:
   - list
   - watch
   - create
+  - delete


### PR DESCRIPTION
Prior to this commit, changing the `kwasm.sh/kwasm-node` from
`true` to `false` caused the operator to fail with a RBAC error.

> User "system:serviceaccount:kwasm:kwasm-operator" cannot delete resource "jobs" in API group "batch" in the namespace "kwasm"
