### PR TITLE
fix: restore SBOM creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,11 @@ jobs:
             core.setFailed(`Draft release not found`)
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: sbom
+          pattern: sbom-*
+          path: ./
+          merge-multiple: true
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: sbom
+          name: sbom-${{ matrix.arch }}
           path: kwasm-operator-sbom-*


### PR DESCRIPTION
The update to `actions/upload-artifact` v4 introduces a breaking change:

> Uploading to the same named Artifact multiple times.
>
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

This is good security improvement.

This commit fixes the build failures we've seen by:

- Uploading x86_64 and ARM64 SBOMs as individual artifacts
- When creating the GitHub release, download all the artifacts produced during the run. The pre-existing code was already looking for the specific SBOM files
