### PR TITLE
chore: using predictable label value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_K8S_VERSION = 1.29.3
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -175,8 +175,8 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
+KUSTOMIZE_VERSION ?= v5.4.2
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/controllers/provisioner_controller.go
+++ b/controllers/provisioner_controller.go
@@ -44,7 +44,7 @@ type ProvisionerReconciler struct {
 
 const (
 	addKWasmNodeLabelAnnotation = "kwasm.sh/kwasm-node"
-	nodeNameLabel               = "kwasm.sh/kwasm-provisioned"
+	provisionedLabel            = "kwasm.sh/kwasm-provisioned"
 )
 
 //+kubebuilder:rbac:groups=wasm.kwasm.sh,resources=provisioners,verbs=get;list;watch;create;update;patch;delete
@@ -83,7 +83,7 @@ func (r *ProvisionerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	*/
 
 	labelShouldBePresent := node.Annotations[addKWasmNodeLabelAnnotation] == "true"
-	labelIsPresent := node.Labels[nodeNameLabel] == node.Name
+	labelIsPresent := node.Labels[provisionedLabel] == "true"
 
 	if labelShouldBePresent == labelIsPresent && !r.AutoProvision {
 		// The desired state and actual state of the Node are the same.
@@ -96,7 +96,7 @@ func (r *ProvisionerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if node.Labels == nil {
 			node.Labels = make(map[string]string)
 		}
-		node.Labels[nodeNameLabel] = node.Name
+		node.Labels[provisionedLabel] = "true"
 		log.Info().Msgf("Trying to Deploy on %s", node.Name)
 
 		dep, err := r.deployJob(node, req)
@@ -110,7 +110,7 @@ func (r *ProvisionerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	} else if !r.AutoProvision {
 		// If the label should not be set but is, remove it.
-		delete(node.Labels, nodeNameLabel)
+		delete(node.Labels, provisionedLabel)
 		log.Info().Msg("Label removed. Removing Job.")
 
 		err := r.Delete(ctx, &batchv1.Job{

--- a/controllers/provisioner_controller_test.go
+++ b/controllers/provisioner_controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ProvisionerController", func() {
 			// Verify that the Node has the expected label.
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(node.Labels["kwasm.sh/kwasm-provisioned"]).To(Equal(nodeName))
+			Expect(node.Labels["kwasm.sh/kwasm-provisioned"]).To(Equal("true"))
 
 			// Call Reconcile again with the same Request object to ensure that the operator
 			// does not create a duplicate Job.


### PR DESCRIPTION
Fixes https://github.com/KWasm/kwasm-operator/issues/146

This changes the label value to be a predictable `"true"` so that it can be easily targeted from the `nodeSelector` in `RuntimeClass` objects.

Also updating some tooling versions.