### PR TITLE
feat: make kwasmDir configurable

### DIFF
--- a/controllers/provisioner_controller.go
+++ b/controllers/provisioner_controller.go
@@ -40,6 +40,7 @@ type ProvisionerReconciler struct {
 	Scheme         *runtime.Scheme
 	AutoProvision  bool
 	InstallerImage string
+	KwasmDir       string
 }
 
 const (
@@ -176,6 +177,10 @@ func (r *ProvisionerReconciler) deployJob(node *corev1.Node, req ctrl.Request) (
 							{
 								Name:  "NODE_ROOT",
 								Value: "/mnt/node-root",
+							},
+							{
+								Name:  "KWASM_DIR",
+								Value: r.KwasmDir,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{

--- a/controllers/provisioner_controller_test.go
+++ b/controllers/provisioner_controller_test.go
@@ -16,6 +16,7 @@ import (
 
 var namespaceName = "kwasm-provisioner"
 var installerImage = "ghcr.io/kwasm/kwasm-node-installer:latest"
+var kwasmDir = "/opt/kwasm"
 
 var _ = Describe("ProvisionerController", func() {
 	Context("Kwasm Provisioner controller test", func() {
@@ -45,6 +46,7 @@ var _ = Describe("ProvisionerController", func() {
 				Client:         k8sClient,
 				Scheme:         k8sClient.Scheme(),
 				InstallerImage: installerImage,
+				KwasmDir:       kwasmDir,
 			}
 			err = k8sClient.Create(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
@@ -92,6 +94,7 @@ var _ = Describe("ProvisionerController", func() {
 				Client:         k8sClient,
 				Scheme:         k8sClient.Scheme(),
 				InstallerImage: installerImage,
+				KwasmDir:       kwasmDir,
 			}
 
 			node = &corev1.Node{
@@ -121,6 +124,7 @@ var _ = Describe("ProvisionerController", func() {
 				Client:         k8sClient,
 				Scheme:         k8sClient.Scheme(),
 				InstallerImage: installerImage,
+				KwasmDir:       kwasmDir,
 				AutoProvision:  true,
 			}
 			node = &corev1.Node{

--- a/main.go
+++ b/main.go
@@ -149,11 +149,18 @@ func main() {
 		setupLog.Info(fmt.Sprintf("INSTALLER_IMAGE=%s", installerImage))
 	}
 
+	kwasmDir := "/opt/kwasm"
+	if kwasmDirEnv, found := os.LookupEnv("KWASM_DIR"); found {
+		kwasmDir = kwasmDirEnv
+		setupLog.Info(fmt.Sprintf("KWASM_DIR=%s", kwasmDir))
+	}
+
 	if err = (&controllers.ProvisionerReconciler{
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		AutoProvision:  autoProvision,
 		InstallerImage: installerImage,
+		KwasmDir:       kwasmDir,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Provisioner")
 		os.Exit(1)


### PR DESCRIPTION
This PR leverages https://github.com/KWasm/kwasm-node-installer/pull/59 and adds the ability to pass to the underlying installer script a `KWASM_DIR` value different than the default `/opt/kwasm`. 

See details in the other PR but essentially the motivation is to make GKE nodes running `cos_containerd` also provisionable.

Needs https://github.com/KWasm/kwasm-node-installer/pull/59 to be merged and a new `kwasm-node-installer` image to be built and released.